### PR TITLE
chore: seed data users

### DIFF
--- a/typescript-backend/mock_data/users.json
+++ b/typescript-backend/mock_data/users.json
@@ -1,0 +1,622 @@
+[
+    {
+        "username": "Trinity",
+        "firebase_uid": "aB3xYz9KlmNOqP456rstUVWX7yza"
+    },
+    {
+        "username": "Safiya", 
+        "firebase_uid": "JkL8MnOpQrSTuvW0xyZa1Bc2DeFg"
+    },
+    {
+        "username": "Celina",
+        "firebase_uid": "hI3jK4LmN5oPqrStUvWxYzAbCdEf"
+    },
+    {
+        "username": "Nadeen",
+        "firebase_uid": "mNoPQr5TuVWX6yzA7bCdEfGhIjKl"
+    },
+    {
+        "username": "Rohan",
+        "firebase_uid": "ZxCvBnM8aS9dFgHiJkL0QwErTyUp"
+    },
+    {
+        "username": "user001",
+        "firebase_uid": "hu8sAffcswkKX6qbFtAHH2U54hJl"
+    },
+    {
+        "username": "user002",
+        "firebase_uid": "OtDFmy91xMUw7w6QpTPh3q84k2LO"
+    },
+    {
+        "username": "user003",
+        "firebase_uid": "SEddsPIZQw3g3p3KiJ0iHZRvF064"
+    },
+    {
+        "username": "user004",
+        "firebase_uid": "IK07ncDgMDa9me4lUYB1tFUrEDw1"
+    },
+    {
+        "username": "user005",
+        "firebase_uid": "HMl1PX2VpPioJXLzPMeAVDwhCTat"
+    },
+    {
+        "username": "user006",
+        "firebase_uid": "70I3I5pjSjQ3lfuKi2Vre3axaP2a"
+    },
+    {
+        "username": "user007",
+        "firebase_uid": "GHe2oH1qswXhzIXaymW7zkvYBGGx"
+    },
+    {
+        "username": "user008",
+        "firebase_uid": "L76KLQT6fLSPom9KayPvgLQh2vsa"
+    },
+    {
+        "username": "user009",
+        "firebase_uid": "bLHtHCupdgPQZPgmMtb4Uw7Yp1Bm"
+    },
+    {
+        "username": "user010",
+        "firebase_uid": "FvfKQHudBXn9PBsUdb2YyNnpXttk"
+    },
+    {
+        "username": "user011",
+        "firebase_uid": "D9F7ctq1pVbkYjL0iOGZSsNbrRMs"
+    },
+    {
+        "username": "user012",
+        "firebase_uid": "WmsrjEF605id9ppvjIXjnLME0Mns"
+    },
+    {
+        "username": "user013",
+        "firebase_uid": "de67ADz6hqI26Qjn6IqyONg0YXy1"
+    },
+    {
+        "username": "user014",
+        "firebase_uid": "zBe5D8ZwU3AS2wUWx5ikLHhNj6wm"
+    },
+    {
+        "username": "user015",
+        "firebase_uid": "53eOuX6VxRj7XBDbWGQAo4caxsC1"
+    },
+    {
+        "username": "user016",
+        "firebase_uid": "OmQWfJMWYvjRVMwo1FDyyF9H395l"
+    },
+    {
+        "username": "user017",
+        "firebase_uid": "KhKZTNEUDIYHyObOz42EL0yRlTAS"
+    },
+    {
+        "username": "user018",
+        "firebase_uid": "ETkCbIfhRLEIGnkOa5wFl71ABSVe"
+    },
+    {
+        "username": "user019",
+        "firebase_uid": "q9Miq7rcR4yDHRuxrGlRFLtfVvaQ"
+    },
+    {
+        "username": "user020",
+        "firebase_uid": "fqCH0FXpQKcD8BnhLKtSa2CbQ2S2"
+    },
+    {
+        "username": "user021",
+        "firebase_uid": "tLXieFTQO8zwn8tKWaSeHT2qlu5j"
+    },
+    {
+        "username": "user022",
+        "firebase_uid": "JBm7vXwVn7ap5rhey5yiObDUFwWM"
+    },
+    {
+        "username": "user023",
+        "firebase_uid": "RsiaZpUCrr0Xb8yQ5xa5Cit0AxIr"
+    },
+    {
+        "username": "user024",
+        "firebase_uid": "pkc59Uzsl15l6ftWd2S4c8Sxs4sw"
+    },
+    {
+        "username": "user025",
+        "firebase_uid": "DYhn20WQF0dnc0wrlc2VcYpdeplc"
+    },
+    {
+        "username": "user026",
+        "firebase_uid": "vzme9FqDRcGmfiGtN6YbKcDl8izH"
+    },
+    {
+        "username": "user027",
+        "firebase_uid": "yNygSNJwndwT8Acw9UA6Z4gmQhtC"
+    },
+    {
+        "username": "user028",
+        "firebase_uid": "b6hl0nCrv3TjOVUSwj4HNxF5ZiB5"
+    },
+    {
+        "username": "user029",
+        "firebase_uid": "SpLRHxKxkZ6Wi2sFxrqvZgMViEsP"
+    },
+    {
+        "username": "user030",
+        "firebase_uid": "7oVtR60LjFl6gE0Jbr5y32CMResf"
+    },
+    {
+        "username": "user031",
+        "firebase_uid": "UVp8uRG45QocBNK37sG9y5d1KOqo"
+    },
+    {
+        "username": "user032",
+        "firebase_uid": "9UlL0Yb9dWet8QgntPms0nQPQD1U"
+    },
+    {
+        "username": "user033",
+        "firebase_uid": "k0vWUq5IxWgxDnaMIxtvvSUnHTUB"
+    },
+    {
+        "username": "user034",
+        "firebase_uid": "ZR8wruUdHfSy0zj4S3W5JjowNoWA"
+    },
+    {
+        "username": "user035",
+        "firebase_uid": "GcgA6geMns3NIucK86ZYMQc0lqrl"
+    },
+    {
+        "username": "user036",
+        "firebase_uid": "RC2QnnBi0KGjxvubM4tNX7KTxNTh"
+    },
+    {
+        "username": "user037",
+        "firebase_uid": "2ocObXyO59wojm42f6YIgIpR7RcX"
+    },
+    {
+        "username": "user038",
+        "firebase_uid": "gW2DdoC2oSWfgumbLCFOmsXUadC2"
+    },
+    {
+        "username": "user039",
+        "firebase_uid": "lnzUBnbXCm9IHQ3Fo37uK59dZ4Rm"
+    },
+    {
+        "username": "user040",
+        "firebase_uid": "HBQc0NZ6qvZvsy7h1PKQil2VbQOO"
+    },
+    {
+        "username": "user041",
+        "firebase_uid": "K7WwJKuvL2MSzanUOFEmp19p90De"
+    },
+    {
+        "username": "user042",
+        "firebase_uid": "bINur4ADhZ7BehKYVI5AFY72PHJU"
+    },
+    {
+        "username": "user043",
+        "firebase_uid": "r3IyYLAx10NEcxPm3unSOlO7mqQk"
+    },
+    {
+        "username": "user044",
+        "firebase_uid": "9pDBHlAC9q5dOeVm3R52X21JHdXL"
+    },
+    {
+        "username": "user045",
+        "firebase_uid": "sWz8DtP596rPUTDYCFyyJ3p7quhX"
+    },
+    {
+        "username": "user046",
+        "firebase_uid": "azw6g0qzH69j7ItHmr87tiAVC784"
+    },
+    {
+        "username": "user047",
+        "firebase_uid": "rPvo0UwMA6TneKADdJm4cQoE1Si6"
+    },
+    {
+        "username": "user048",
+        "firebase_uid": "uuFz55tvAShzOytwtBc0zPBvdHPW"
+    },
+    {
+        "username": "user049",
+        "firebase_uid": "cd7tGa4hvEpi6mpnghk1wW5wLAsQ"
+    },
+    {
+        "username": "user050",
+        "firebase_uid": "sxtXtCK4wpg9OytzszvdJhOf0hn5"
+    },
+    {
+        "username": "user051",
+        "firebase_uid": "DMs00avj0CSanlEhqqD5dtiVip2A"
+    },
+    {
+        "username": "user052",
+        "firebase_uid": "LsbhoSx2axczfIDxZxB9Toi8Xv5s"
+    },
+    {
+        "username": "user053",
+        "firebase_uid": "V8X3nz8MsvSNY7jNHkaSchrcC6E0"
+    },
+    {
+        "username": "user054",
+        "firebase_uid": "UHKTHIDXTC0JaTA0t5i8NOZuTGVO"
+    },
+    {
+        "username": "user055",
+        "firebase_uid": "hsFXuME6w2ma178ubcmjtWHJGydg"
+    },
+    {
+        "username": "user056",
+        "firebase_uid": "SKIxNRW8s6cKfhbQWhBch0J4UeOl"
+    },
+    {
+        "username": "user057",
+        "firebase_uid": "Vv6lwTfpOytnSETJyzYs3XFPP946"
+    },
+    {
+        "username": "user058",
+        "firebase_uid": "ProfbocNfgwC6dPQYkcKQ6DwGXIc"
+    },
+    {
+        "username": "user059",
+        "firebase_uid": "2WUOqepwR5iHYr6Gu4k0YOeyF39i"
+    },
+    {
+        "username": "user060",
+        "firebase_uid": "IDT33gPzRIaaSW3aA6BLVrNJlVkr"
+    },
+    {
+        "username": "user061",
+        "firebase_uid": "kdCsxAtu3m72BpuE84f0kcDYU6F6"
+    },
+    {
+        "username": "user062",
+        "firebase_uid": "pmr6yFOfsOFZtsWIvUbyjrMzfnt6"
+    },
+    {
+        "username": "user063",
+        "firebase_uid": "DgL9H7XeXfSh6AiS9fzgCJs3OU0Z"
+    },
+    {
+        "username": "user064",
+        "firebase_uid": "WuVpxPzFcm3jm0I9YB6hFZiZBatp"
+    },
+    {
+        "username": "user065",
+        "firebase_uid": "FkQ73GTL2K9Lm0kIlxVYFRGSchdr"
+    },
+    {
+        "username": "user066",
+        "firebase_uid": "5GGGMDMITx0CadzDGyMTx4ECSLpM"
+    },
+    {
+        "username": "user067",
+        "firebase_uid": "0Bj6Zkn6sucOccK995b0U09WEOR7"
+    },
+    {
+        "username": "user068",
+        "firebase_uid": "6twBSRUBpSrwg0dluPyuG7abkpF5"
+    },
+    {
+        "username": "user069",
+        "firebase_uid": "cXa4LX9nNE8JAtzYUy2kxemhUWb9"
+    },
+    {
+        "username": "user070",
+        "firebase_uid": "pF6JvrZCa7tOFL3wsrr0g7VfInj6"
+    },
+    {
+        "username": "user071",
+        "firebase_uid": "Z8uMnVd8ccWdL32VAxBj5ulw37Fa"
+    },
+    {
+        "username": "user072",
+        "firebase_uid": "CNw6YGGpUbtRFHUmp7VDd1XtLlvc"
+    },
+    {
+        "username": "user073",
+        "firebase_uid": "NR801wClNNMzyPwscFiJFhfD8zQH"
+    },
+    {
+        "username": "user074",
+        "firebase_uid": "VHzhqMDCdDizVQBOHf9bMsm90HdZ"
+    },
+    {
+        "username": "user075",
+        "firebase_uid": "8krCPOTRrsscHP2p5HCHVrTnPDgg"
+    },
+    {
+        "username": "user076",
+        "firebase_uid": "qnZv92bGEr9EDso4RKT4eO3e40Vc"
+    },
+    {
+        "username": "user077",
+        "firebase_uid": "VjcJCCEHqssV7WIELc11NdbFRanN"
+    },
+    {
+        "username": "user078",
+        "firebase_uid": "2qilmQ7p5aEsKCqwamwjqAI8nhq2"
+    },
+    {
+        "username": "user079",
+        "firebase_uid": "eJWq0LN21bIPpq4xa7ajWKutHbp4"
+    },
+    {
+        "username": "user080",
+        "firebase_uid": "JESBbZ3xvnSlpBQH0yU5yHEF61TY"
+    },
+    {
+        "username": "user081",
+        "firebase_uid": "LCMifFb7ZLRn1NpsYeihHzx5lSaY"
+    },
+    {
+        "username": "user082",
+        "firebase_uid": "04s7FHZoL5P3sRGVbfc3GtKPGBmW"
+    },
+    {
+        "username": "user083",
+        "firebase_uid": "UEYyvIP3ayqGOJqyt4OrP9jjS18F"
+    },
+    {
+        "username": "user084",
+        "firebase_uid": "lynsCgKP3gXgyYy4OoQsFod5DCpv"
+    },
+    {
+        "username": "user085",
+        "firebase_uid": "mZvlUg75YeIUcFWDI8ygfrKlAe3F"
+    },
+    {
+        "username": "user086",
+        "firebase_uid": "in5P2eYScJfgkSRw6bbKcjEJ418d"
+    },
+    {
+        "username": "user087",
+        "firebase_uid": "6YyoM9PXMK1HYutXfHFK44M6xAOQ"
+    },
+    {
+        "username": "user088",
+        "firebase_uid": "Uc0oDsfvrEXTkGeJQLsw90Ta8rEC"
+    },
+    {
+        "username": "user089",
+        "firebase_uid": "MFGoVnxZe5LY2PPgtck1TdGg6qTW"
+    },
+    {
+        "username": "user090",
+        "firebase_uid": "GjtHyLXkSqvMu3URk7WReCQiMWyc"
+    },
+    {
+        "username": "user091",
+        "firebase_uid": "rqUUGLRD8CqSKw5UhnmFkyJZwzBN"
+    },
+    {
+        "username": "user092",
+        "firebase_uid": "VFtIGoYpO793VnpHOIhY43NXgAqG"
+    },
+    {
+        "username": "user093",
+        "firebase_uid": "NA4ta7VxO8aV86Q9kVdW9GLjKst6"
+    },
+    {
+        "username": "user094",
+        "firebase_uid": "A9WQtNO20ScJosuRcTZvKas1nqgV"
+    },
+    {
+        "username": "user095",
+        "firebase_uid": "1GCuLLZzHK415ryLKuYu9zeI3B6l"
+    },
+    {
+        "username": "user096",
+        "firebase_uid": "1kN51IHBKrLuUjwxYKzXyymaD5jJ"
+    },
+    {
+        "username": "user097",
+        "firebase_uid": "aqpiHKk3xCDtEd93VNVypi7xSzBP"
+    },
+    {
+        "username": "user098",
+        "firebase_uid": "0rF4pHUxZ0nPo3k27rgJvpj6mqCN"
+    },
+    {
+        "username": "user099",
+        "firebase_uid": "QdMj2yV767BRN3np0xwbnQXkTKwo"
+    },
+    {
+        "username": "user100",
+        "firebase_uid": "fkBO8JnmqGHCaPJJOPJz9yWuMJ26"
+    },
+    {
+        "username": "user101",
+        "firebase_uid": "fQZBJNbLtaFgsXVErYQ7UJh103Hj"
+    },
+    {
+        "username": "user102",
+        "firebase_uid": "HdkguJDCGQzo63FGNFak35CFalaN"
+    },
+    {
+        "username": "user103",
+        "firebase_uid": "vctzvYBCfDrrh1APdwLhxBa01rJH"
+    },
+    {
+        "username": "user104",
+        "firebase_uid": "8y6Lo1LWJY9oXIhbVIyACSgr78KN"
+    },
+    {
+        "username": "user105",
+        "firebase_uid": "lFcf2cmsjMesns3O59cRVy6BB2iB"
+    },
+    {
+        "username": "user106",
+        "firebase_uid": "jpdMvQ8cXVWLlaWU5CAXal9nF9aL"
+    },
+    {
+        "username": "user107",
+        "firebase_uid": "FwqILz7KLLU9E8970a5El4Eiflpb"
+    },
+    {
+        "username": "user108",
+        "firebase_uid": "bWjC9IKQElI7kF9T9BouTeaqQYlt"
+    },
+    {
+        "username": "user109",
+        "firebase_uid": "K4XCBX2TWRNyvDLUqJEBOAieUZFm"
+    },
+    {
+        "username": "user110",
+        "firebase_uid": "pkFD2dpb0rCUeZTZKo4dXworjaJL"
+    },
+    {
+        "username": "user111",
+        "firebase_uid": "IiusyiiDlybQ6YROygyxTAQCwcmG"
+    },
+    {
+        "username": "user112",
+        "firebase_uid": "cGMgQ0B3oqWaA414LAVM3g3ib8I7"
+    },
+    {
+        "username": "user113",
+        "firebase_uid": "GCwY5QEZnjK3pHMSqMscwS4toWib"
+    },
+    {
+        "username": "user114",
+        "firebase_uid": "huF4LToXoOU7LcUsFpD0NpAc15VX"
+    },
+    {
+        "username": "user115",
+        "firebase_uid": "uwVTNzZKWi8TxFrDWoHPoimhYrjZ"
+    },
+    {
+        "username": "user116",
+        "firebase_uid": "mncPV3iBdHpr1fhkPZEIwkNoFebE"
+    },
+    {
+        "username": "user117",
+        "firebase_uid": "Jg4vDF3TvE2QVesMFyBXs7gaVKCZ"
+    },
+    {
+        "username": "user118",
+        "firebase_uid": "CHyfnRrdJCSsU0ZTv1WTSaKA0xjc"
+    },
+    {
+        "username": "user119",
+        "firebase_uid": "QKsmceLYoYQ46E8UWBJ5dxOaeA2H"
+    },
+    {
+        "username": "user120",
+        "firebase_uid": "8ntEtAZHG35pVun6iu3gl46EhowO"
+    },
+    {
+        "username": "user121",
+        "firebase_uid": "5H0xO3xJCQYM33aEPZ1WMdl2KW49"
+    },
+    {
+        "username": "user122",
+        "firebase_uid": "BtduWAKRm1wqlrWQSCI0GDPDfcQt"
+    },
+    {
+        "username": "user123",
+        "firebase_uid": "pPJdYgozIbT4n1Fx1lqPb2HfAeek"
+    },
+    {
+        "username": "user124",
+        "firebase_uid": "5QQVLov5woqB8PAiKhyJAuTf3T4f"
+    },
+    {
+        "username": "user125",
+        "firebase_uid": "fpSbFUFF3MYUqk3vu1LCJGOxynAO"
+    },
+    {
+        "username": "user126",
+        "firebase_uid": "CJ6o3g1uHMCZMhQ8FwAOIlP24Jnl"
+    },
+    {
+        "username": "user127",
+        "firebase_uid": "mVAeFkqH5dU4Ps1tHwq4MSiHN1AZ"
+    },
+    {
+        "username": "user128",
+        "firebase_uid": "VHb4EOwuUPjOFWRSXBO4o5trwwRm"
+    },
+    {
+        "username": "user129",
+        "firebase_uid": "ocEwRyfIOruJj6LBWPntIWt3jXfH"
+    },
+    {
+        "username": "user130",
+        "firebase_uid": "7wEZyR7XpwuBxER3efQs5hS7oNBh"
+    },
+    {
+        "username": "user131",
+        "firebase_uid": "RoWwtk6neTqTxgGRJSav7CiGmmGu"
+    },
+    {
+        "username": "user132",
+        "firebase_uid": "Lx2zAaX2MrmrGACteSPVvZXzaGlH"
+    },
+    {
+        "username": "user133",
+        "firebase_uid": "lOm118VF3QddXdGum3RMgvqYto6Y"
+    },
+    {
+        "username": "user134",
+        "firebase_uid": "Odc58K5iK6BVgFvP9HO8mVNFbyLC"
+    },
+    {
+        "username": "user135",
+        "firebase_uid": "zq2YY1wAlPypF2kUUaL3FG4ZrVFS"
+    },
+    {
+        "username": "user136",
+        "firebase_uid": "pDEd5z4dh3pGs603BA4hES50PYsa"
+    },
+    {
+        "username": "user137",
+        "firebase_uid": "kLZmfiSGgOkd3yty1lgjeUlbJVl7"
+    },
+    {
+        "username": "user138",
+        "firebase_uid": "MQCaxigQhaayCk8CUNxVjfpbmvyU"
+    },
+    {
+        "username": "user139",
+        "firebase_uid": "iKQz0vVvfrIl3DoPeQv6i6ccrUDv"
+    },
+    {
+        "username": "user140",
+        "firebase_uid": "1bM5qL825b1RlEyCj6pxYkoHGk6b"
+    },
+    {
+        "username": "user141",
+        "firebase_uid": "fltbxZNowskZ7d4hBgpj5DUIskbw"
+    },
+    {
+        "username": "user142",
+        "firebase_uid": "Z73ymu4qmtSWzRH3ecMUNf6Mmdu1"
+    },
+    {
+        "username": "user143",
+        "firebase_uid": "DMpa9g1Tkzz9WtCaHbp5ByIvud1D"
+    },
+    {
+        "username": "user144",
+        "firebase_uid": "DOVCxH2yu73KorJNRNWS78hmaDIf"
+    },
+    {
+        "username": "user145",
+        "firebase_uid": "tnsh1rjE11cUq08vy0Eht6chy8QN"
+    },
+    {
+        "username": "user146",
+        "firebase_uid": "hBbrzJfLTtPXEyuylKSUj8n9LAGO"
+    },
+    {
+        "username": "user147",
+        "firebase_uid": "6BBGxtyiFev3NbnQmeWdnTooC2Lv"
+    },
+    {
+        "username": "user148",
+        "firebase_uid": "cOV28cESrGaLhRbM4nfFgmhE27Uz"
+    },
+    {
+        "username": "user149",
+        "firebase_uid": "h3w0b7wgKubuRw0H0cqytRdDNID9"
+    },
+    {
+        "username": "user150",
+        "firebase_uid": "buhACp8iU8l90B166nfEbMzj17DE"
+    }
+]

--- a/typescript-backend/scripts/seed.js
+++ b/typescript-backend/scripts/seed.js
@@ -28,14 +28,9 @@ async function seedDatabase() {
         `);
         
         await client.query('TRUNCATE "User", "Cafe" RESTART IDENTITY CASCADE');
-        
-        const users = [ // warning the firebase uids are all FAKE!!
-            { username: 'Trinity', firebase_uid: 'aB3xYz9KlmNOqP456rstUVWX7yza'},
-            { username: 'Safiya', firebase_uid: 'JkL8MnOpQrSTuvW0xyZa1Bc2DeFg'},
-            { username: 'Celina', firebase_uid: 'hI3jK4LmN5oPqrStUvWxYzAbCdEf'},
-            { username: 'Nadeen', firebase_uid: 'mNoPQr5TuVWX6yzA7bCdEfGhIjKl'},
-            { username: 'Rohan', firebase_uid: 'ZxCvBnM8aS9dFgHiJkL0QwErTyUp'},
-        ];
+
+        // warning the firebase uids as part of this data are all FAKE!!
+        const users = require('../mock_data/users.json');
         
         for (const user of users) {
             await client.query(


### PR DESCRIPTION
Added seeded data for users table.

Note: right now, you have to do first do `docker compose down -v` (which removes all the volumes as well) and then do `docker compose up -d --build` everytime your seeding data changes because JSON files are copied during build and so just doing docker compose down and then up won't work since old JSON files will still be inside. 

This results in building each time, which is very annoying! For now it's fine, but will look into maybe seeding data after build so changes are easier to make in seeding data which will also shorten the build time! 