### PR TITLE
chore: change docker file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,14 @@ services:
     container_name: cafe_hopper_db
     image: postgres:15
     restart: always
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
+    env_file:
+      - ./typescript-backend/.env
     ports:
       - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 30
@@ -28,13 +26,8 @@ services:
       db:
         condition: service_healthy
         restart: true
-    environment:
-      - POSTGRES_DATABASE_URL=${POSTGRES_DATABASE_URL}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_HOST=${POSTGRES_HOST}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_PORT=${POSTGRES_PORT}
+    env_file:
+      - ./typescript-backend/.env
     ports:
       - '3001:8080'
     restart: always


### PR DESCRIPTION
Having a .env in the root with backend environment variables didn't make sense. 

Making this change will now read the necessary env needed for both the db and the seeding script from the .env in the backend directory itself.

IMPORTANT: You will now need to move your existing .env in the root to "typescript-backend" folder for the docker to work. 

Testing instructions:

1. Move the .env file from root to "typescript-backend" folder
2. Run the command: `docker compose down -v` followed by `docker compose up -d --build`
3. For all the containers in Docker, make sure no errors appear. 
4. Try hitting one of the backend endpoints to see if data has been seeded properly ( or just click this link http://localhost:3001/users)