### PR TITLE
critical fix to getTableSchema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+react-frontend/.env
+typescript-backend/src/firebase/cafe-hopper-460919-firebase-adminsdk-fbsvc-15066907fe.json

--- a/typescript-backend/orm/custom.js
+++ b/typescript-backend/orm/custom.js
@@ -17,9 +17,12 @@ class CustomModel {
 
   // get a tableSchema object with keys representing column name and the values representing the columns type
   async #getTableSchema() {
-    const client = await pool.connect();
+    if (this.#tableSchema) {
+      return this.#tableSchema; 
+    }
 
-    if (!this.#tableSchema) {
+    const client = await pool.connect();
+    try {
       this.#tableSchema = {};
       const tableDataQuery = `
         SELECT column_name, data_type
@@ -31,8 +34,8 @@ class CustomModel {
         this.#tableSchema[tableDataTuple.column_name] = tableDataTuple.data_type;
       });
       return this.#tableSchema;
-    } else {
-      return this.#tableSchema;
+    } finally {
+      client.release(); 
     }
   }
 


### PR DESCRIPTION
Critical fix to release the connection once connected! 🚨 

The current implementation of the getTableSchema opens a connection to the database but never closes it. This resulted in making API calls which initially ran fine but then after that there were massive number of pending requests because of this. 

Before:
<img width="958" height="461" alt="image" src="https://github.com/user-attachments/assets/80c38653-0d8f-4636-bd54-f41d1f889ffa" />

After:
<img width="952" height="545" alt="image" src="https://github.com/user-attachments/assets/a817279b-1edf-431d-89d1-d482c09148a5" />
