### PR TITLE
Minor fixes to create and quoteProperties functions

### DIFF
--- a/typescript-backend/orm/custom.js
+++ b/typescript-backend/orm/custom.js
@@ -60,7 +60,7 @@ class CustomModel {
     ]);
 
     const quotedProperties = {}
-    keyNames.map(key => {
+    keyNames.forEach(key => {
       if (quotedTypes.has(tableSchema[key])) { // if the key's type is in quoted types, surround w/ quotes
         quotedProperties[key] = `'${object[key]}'`;
       } else {
@@ -115,6 +115,7 @@ class CustomModel {
       return result.rows[0];
     } catch (e) {
       console.error(e);
+      throw e;
     } finally {
       client.release();
     }


### PR DESCRIPTION
Made some minor fixes to the orm for things that gave me trouble during testing
- made sure that error was being thrown in the create function
- switched map to forEach in getTableSchema since we don't need to transform the array or use its return value (we're just populating an object)